### PR TITLE
fixed wrong filename for runpreview.sh

### DIFF
--- a/image-opensim/Dockerfile-opensim
+++ b/image-opensim/Dockerfile-opensim
@@ -67,7 +67,7 @@ RUN cd $OPENSIMDIR \
 
 # Build OpenSimulator
 RUN cd $OPENSIMDIR \
-    && chmod +x runprebuild48.sh \
+    && chmod +x runprebuild.sh \
     && ./runprebuild.sh \
     && dotnet build --configuration Release OpenSim.sln
 


### PR DESCRIPTION
runpreview48.sh does not exist in the dotnet6 branch. without a rename to runpreview.sh docker build fails.